### PR TITLE
Delete classes from back-end

### DIFF
--- a/src/app/class-storage.service.ts
+++ b/src/app/class-storage.service.ts
@@ -136,7 +136,14 @@ export class ClassStorageService {
     }
   }
 
-
+    //deletes class in array
+    deleteClass (classname: String) {
+	for (var i = 0; i < this.allClasses.length; i++) {
+	    if (this.allClasses[i]['name'] === classname) {
+		this.allClasses.splice(i,1);
+	    }
+	}
+    }
 
  // this function outputs the current diagram as a JSON string
   diagramToJSON(){

--- a/src/app/class-storage.service.ts
+++ b/src/app/class-storage.service.ts
@@ -138,11 +138,14 @@ export class ClassStorageService {
 
     //deletes class in array
     deleteClass (classname: String) {
+	var successVal = false;
 	for (var i = 0; i < this.allClasses.length; i++) {
 	    if (this.allClasses[i]['name'] === classname) {
 		this.allClasses.splice(i,1);
+		successVal = true;
 	    }
 	}
+	return successVal;
     }
 
  // this function outputs the current diagram as a JSON string

--- a/src/app/cli/cli.component.ts
+++ b/src/app/cli/cli.component.ts
@@ -61,7 +61,12 @@ export class CliComponent implements OnInit, AfterViewInit {
         default: output = "Error: Invalid Command. Type \"h\" for help"; break;
       }
       return output;
-  }
+    }
+
+    //wrapper class to delete class from backend given classname to delete
+    deleteClass(classname) {
+	this.service.deleteClass(classname);
+    }
 
   //this outputs the current JSON to the terminal screen
   exportDiagram(){

--- a/src/app/cli/cli.component.ts
+++ b/src/app/cli/cli.component.ts
@@ -65,6 +65,7 @@ export class CliComponent implements OnInit, AfterViewInit {
 
     //wrapper class to delete class from backend given classname to delete
     deleteClass(classname) {
+	//if classname is invalid, function does nothing
 	this.service.deleteClass(classname);
     }
 

--- a/src/app/cli/cli.component.ts
+++ b/src/app/cli/cli.component.ts
@@ -65,8 +65,13 @@ export class CliComponent implements OnInit, AfterViewInit {
 
     //wrapper class to delete class from backend given classname to delete
     deleteClass(classname) {
-	//if classname is invalid, function does nothing
-	this.service.deleteClass(classname);
+	var deleted = this.service.deleteClass(classname);
+	if (deleted == true) {
+	    return classname + " successfully deleted\r\n";
+	}
+	else {
+	    return "Please enter a valid class name to delete.\r\n";
+	}
     }
 
   //this outputs the current JSON to the terminal screen

--- a/src/app/dialog-test/dialog-test.component.html
+++ b/src/app/dialog-test/dialog-test.component.html
@@ -62,7 +62,7 @@
             <mat-option *ngFor="let className of classNames" value="{{className.innerHTML}}" >{{className.innerHTML}}</mat-option>
           </mat-select> 
       </mat-form-field>
-      <button mat-raised-button color="primary" [mat-dialog-close] type="button" (click)="search(choice)">Deleted Class</button>
+      <button mat-raised-button color="primary" [mat-dialog-close] type="button" (click)="deleteClass(choice)">Deleted Class</button>
   </form>
 </span> 
 <!-- export button contents -->

--- a/src/app/dialog-test/dialog-test.component.ts
+++ b/src/app/dialog-test/dialog-test.component.ts
@@ -117,5 +117,11 @@ export class DialogTestComponent implements OnInit {
 
   updateStoredDiagram(){
     this.service.diagramToJSON();
-  }  
+  }
+
+    //wrapper class for service delete method
+    //note: currently only deletes from back-end array
+    deleteClass(classname) {
+	this.service.deleteClass(classname);
+    }
 }


### PR DESCRIPTION
### What this *does*
- implements deleteClass function in class-storage, which, given a class name, searches for the class and deletes it from the back-end storage if found; returns true if class name is found & deleted, false otherwise
- connects the above class to the Delete Class button in the GUI via a wrapper function
- inserts a similar wrapper class into the CLI that returns a string asking the user to input a valid class name if deleteClass returns false

### What this does *not* do
- remove classes from the front-end DOM / remove class-boxes from the GUI view
- allow the user to delete classes via the CLI (i.e. does not directly implement the CLI's "r" command)

An interesting, probably obvious, side effect of this incomplete (back-end-only) implementation is that, while the Delete Class button does not seem to have any immediate effect when clicked (unless you examine the JSON string from Export), switching to CLI and back again 'applies' the changes.